### PR TITLE
chroot: sanitize path

### DIFF
--- a/src/chroot.c
+++ b/src/chroot.c
@@ -76,6 +76,9 @@ wrapper(chroot, int, (const char * path))
     else {
         if (*path == '/') {
             expand_chroot_rel_path(path);
+            strlcpy(tmp, path, FAKECHROOT_PATH_MAX);
+            dedotdot(tmpptr);
+            path = tmpptr;
         }
         else {
             snprintf(tmp, FAKECHROOT_PATH_MAX, "%s/%s", cwd, path);

--- a/test/t/chroot.t
+++ b/test/t/chroot.t
@@ -3,7 +3,7 @@
 srcdir=${srcdir:-.}
 . $srcdir/common.inc.sh
 
-prepare 12
+prepare 14
 
 $srcdir/testtree.sh testtree/testtree2
 test "`cat testtree/testtree2/CHROOT`" = "testtree/testtree2" || bail_out "testtree/testtree"
@@ -14,7 +14,7 @@ for chroot in chroot fakechroot; do
         skip $(( $tap_plan / 2 )) "not root"
     else
 
-        for testtree in testtree2 /testtree2 ./testtree2 /./testtree2 testtree2/. testtree2/./.; do
+        for testtree in testtree2 /testtree2 ./testtree2 /./testtree2 testtree2/. testtree2/./. testtree2/; do
             t=`$srcdir/$chroot.sh testtree /usr/sbin/chroot $testtree /bin/cat /CHROOT 2>&1`
             test "$t" = "testtree/testtree2" || not
             ok "$chroot chroot $testtree:" $t


### PR DESCRIPTION
path was not being sanitized if it started with '/' causing chroot calls
to fail when path ended with '/'.

Signed-off-by: Andrew Gregory andrew.gregory.8@gmail.com
