### PR TITLE
Improve dynamic loader functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,7 @@ AC_CHECK_HEADERS(m4_normalize([
     ftw.h
     glob.h
     libintl.h
+    link.h
     pwd.h
     shadow.h
     signal.h
@@ -157,6 +158,8 @@ AC_CHECK_FUNCS(m4_normalize([
     connect
     creat
     creat64
+    dl_iterate_phdr
+    dladdr
     dlmopen
     dlopen
     eaccess

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,6 +41,8 @@ libfakechroot_la_SOURCES = \
     creat64.c \
     dedotdot.c \
     dedotdot.h \
+    dl_iterate_phdr.c \
+    dladdr.c \
     dlmopen.c \
     dlopen.c \
     eaccess.c \

--- a/src/dl_iterate_phdr.c
+++ b/src/dl_iterate_phdr.c
@@ -1,0 +1,52 @@
+/*
+    libfakechroot -- fake chroot environment
+    Copyright (c) 2014 Robin McCorkell <rmccorkell@karoshi.org.uk>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+
+#include <config.h>
+
+#ifdef HAVE_DL_ITERATE_PHDR
+
+#define _GNU_SOURCE
+#include <link.h>
+
+#include "libfakechroot.h"
+
+
+#define DL_ITERATE_PHDR_CALLBACK_ARGS struct dl_phdr_info * info, size_t size, void * data
+
+static int (* dl_iterate_phdr_callback_saved)(DL_ITERATE_PHDR_CALLBACK_ARGS);
+
+static int dl_iterate_phdr_callback(DL_ITERATE_PHDR_CALLBACK_ARGS)
+{
+    if (info->dlpi_name) {
+        narrow_chroot_path(info->dlpi_name);
+    }
+    return dl_iterate_phdr_callback_saved(info, size, data);
+}
+
+wrapper(dl_iterate_phdr, int, (int (* callback)(DL_ITERATE_PHDR_CALLBACK_ARGS), void * data))
+{
+    debug("dl_iterate_phdr(&callback, 0x%x)", data);
+    dl_iterate_phdr_callback_saved = callback;
+    return nextcall(dl_iterate_phdr)(dl_iterate_phdr_callback, data);
+}
+
+#else
+typedef int empty_translation_unit;
+#endif

--- a/src/dladdr.c
+++ b/src/dladdr.c
@@ -1,0 +1,51 @@
+/*
+    libfakechroot -- fake chroot environment
+    Copyright (c) 2014 Robin McCorkell <rmccorkell@karoshi.org.uk>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+
+#include <config.h>
+
+#ifdef HAVE_DLADDR
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+
+#include "libfakechroot.h"
+
+
+wrapper(dladdr, int, (const void * addr, Dl_info * info))
+{
+    int ret;
+
+    debug("dladdr(0x%x, &info)", addr);
+
+    ret = nextcall(dladdr)(addr, info);
+
+    if (info->dli_fname) {
+        narrow_chroot_path(info->dli_fname);
+    }
+    if (info->dli_sname) {
+        narrow_chroot_path(info->dli_sname);
+    }
+
+    return ret;
+}
+
+#else
+typedef int empty_translation_unit;
+#endif

--- a/src/dlopen.c
+++ b/src/dlopen.c
@@ -1,6 +1,7 @@
 /*
     libfakechroot -- fake chroot environment
     Copyright (c) 2010, 2013 Piotr Roszatycki <dexter@debian.org>
+    Copyright (c) 2014 Robin McCorkell <rmccorkell@karoshi.org.uk>
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -20,12 +21,16 @@
 
 #include <config.h>
 
+#include <string.h>
 #include "libfakechroot.h"
 
 
 wrapper(dlopen, void *, (const char * filename, int flag))
 {
     debug("dlopen(\"%s\", %d)", filename, flag);
-    expand_chroot_path(filename);
+    if (strchr(filename, '/') != NULL) {
+        expand_chroot_path(filename);
+        debug("dlopen(\"%s\", %d)", filename, flag);
+    }
     return nextcall(dlopen)(filename, flag);
 }


### PR DESCRIPTION
OpenJDK requires `dladdr` and `dl_iterate_phdr` to get the path to the installed JRE. These functions need to be overridden to convert the paths. Likewise, it uses `dlopen` to search for libraries, which shouldn't be converted.