### PR TITLE
initialize sockaddr.sa_family before reading

### DIFF
--- a/src/getsockname.c
+++ b/src/getsockname.c
@@ -24,6 +24,7 @@
 
 #define _GNU_SOURCE
 #include <sys/socket.h>
+#include <stddef.h>
 
 #ifdef AF_UNIX
 
@@ -44,30 +45,29 @@
 wrapper(getsockname, int, (int s, GETSOCKNAME_TYPE_ARG2(addr), socklen_t * addrlen))
 {
     int status;
-    socklen_t newaddrlen;
-    struct sockaddr_un newaddr;
+    socklen_t origlen = *addrlen;
 
     debug("getsockname(%d, &addr, &addrlen)", s);
 
-    if (SOCKADDR(addr)->sa_family != AF_UNIX) {
-        return nextcall(getsockname)(s, addr, addrlen);
+    status = nextcall(getsockname)(s, addr, addrlen);
+    if (status == 0 && SOCKADDR(addr)->sa_family == AF_UNIX) {
+        struct sockaddr_un *addr_un = SOCKADDR_UN(addr);
+        size_t path_max = origlen - offsetof(struct sockaddr_un, sun_path);
+        if(path_max > origlen) {
+            /* underflow, addr does not have space for the path */
+            return status;
+        } else if(path_max > sizeof(addr_un->sun_path)) {
+            path_max = sizeof(addr_un->sun_path);
+        }
+        if (addr_un->sun_path && *(addr_un->sun_path)) {
+            char tmp[FAKECHROOT_PATH_MAX];
+            strlcpy(tmp, addr_un->sun_path, FAKECHROOT_PATH_MAX);
+            narrow_chroot_path(tmp);
+            strlcpy(addr_un->sun_path, tmp, path_max);
+            *addrlen = SUN_LEN(addr_un);
+        }
     }
 
-    newaddrlen = sizeof(struct sockaddr_un);
-    memset(&newaddr, 0, newaddrlen);
-    status = nextcall(getsockname)(s, (struct sockaddr *)&newaddr, &newaddrlen);
-    if (status != 0) {
-        return status;
-    }
-    if (newaddr.sun_family == AF_UNIX && newaddr.sun_path && *(newaddr.sun_path)) {
-        char tmp[FAKECHROOT_PATH_MAX];
-        strlcpy(tmp, newaddr.sun_path, FAKECHROOT_PATH_MAX);
-        narrow_chroot_path(tmp);
-        strlcpy(newaddr.sun_path, tmp, UNIX_PATH_MAX);
-    }
-
-    memcpy((struct sockaddr_un *)SOCKADDR_UN(addr), &newaddr, *addrlen < sizeof(struct sockaddr_un) ? *addrlen : sizeof(struct sockaddr_un));
-    *addrlen = SUN_LEN(&newaddr);
     return status;
 }
 


### PR DESCRIPTION
getpeername and getsockname do not require callers to initialize the
sockaddr argument, leading to undefined behavior.  Delay the sa_family
check until after it has been set by the wrapped function.

Discovered running a curl-linked program through valgrind.
https://github.com/bagder/curl/blob/aa5808b504fa7d3093c480b4c4c8d82d32921709/lib/connect.c#L675