### PR TITLE
Treat /etc/malloc.conf as non-existing

### DIFF
--- a/src/readlink.c
+++ b/src/readlink.c
@@ -32,6 +32,10 @@ wrapper(readlink, READLINK_TYPE_RETURN, (const char * path, char * buf, READLINK
     const char *fakechroot_base = getenv("FAKECHROOT_BASE");
 
     debug("readlink(\"%s\", &buf, %zd)", path, bufsiz);
+    if (!strcmp(path, "/etc/malloc.conf")) {
+        errno = ENOENT;
+        return -1;
+    }
     expand_chroot_path(path);
 
     if ((linksize = nextcall(readlink)(path, tmp, FAKECHROOT_PATH_MAX-1)) == -1) {


### PR DESCRIPTION
This avoids deadlocks during initialization in multi-threaded programs.
If one really wants malloc configuration, one has to use `MALLOC_OPTIONS` manually.
This patch doesn't automate that process, since it seems to be a rather rare case.
Fixes #31.