### PR TITLE
Add empty audit_log_acct_message function

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -69,3 +69,6 @@ Copyright (C) 2003, 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
 
 strlcpy function taken from OpenBSD.
 Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+
+audit_log_acct_message function taken from Debian bug #745082.
+Copyright (c) 2015 JH Chatenet <jhcha54008@free.fr>

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,7 @@ AC_CHECK_FUNCS(m4_normalize([
     _xftw64
     access
     acct
+    audit
     bind
     bindtextdomain
     canonicalize_file_name

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,6 +28,7 @@ libfakechroot_la_SOURCES = \
     _xftw64.c \
     access.c \
     acct.c \
+    audit.c \
     bind.c \
     bindtextdomain.c \
     canonicalize_file_name.c \

--- a/src/audit.c
+++ b/src/audit.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2015      JH Chatenet <jhcha54008@free.fr>
+ *
+ * Licensed under the LGPL v2.1.
+*/
+
+#include "libfakechroot.h"
+
+wrapper(audit_log_acct_message, int, (int audit_fd, int type, const char *pgname, const char *op, const char *name, unsigned int id, const char *host, const char *addr, const char *tty, int result))
+{
+    return 0;
+}


### PR DESCRIPTION
Override the libaudit audit_log_acct_message() function so that it always returns success. This works around permission problems with pam-related commands on systems where libpam is compiled with audit support.

On Debian and Ubuntu, audit support was introduced in revision 1110 to [pkg-pam](https://anonscm.debian.org/bzr/pkg-pam/debian/sid/), included in Debian's pam 1.1.3-8 (Wheezy uses 1.1.3-7.1; Jessie uses 1.1.8-3.1), to address Debian bug [#699159](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=699159) and LP bug [#937005](https://bugs.launchpad.net/ubuntu/+source/pam/+bug/937005).

Original fake_audit_log_acct_message suggested by JH Chatenet in Debian bug [#745082](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=745082#75).