### PR TITLE
chroot: strip trailing '/' from path

### DIFF
--- a/src/chroot.c
+++ b/src/chroot.c
@@ -75,6 +75,7 @@ wrapper(chroot, int, (const char * path))
         expand_chroot_path(path);
     }
     else {
+        size_t tmplen;
         if (*path == '/') {
             expand_chroot_rel_path(path);
             strlcpy(tmp, path, FAKECHROOT_PATH_MAX);
@@ -85,6 +86,10 @@ wrapper(chroot, int, (const char * path))
             snprintf(tmp, FAKECHROOT_PATH_MAX, "%s/%s", cwd, path);
             dedotdot(tmpptr);
             path = tmpptr;
+        }
+        tmplen = strlen(tmpptr);
+        while(tmplen > 1 && tmpptr[tmplen - 1] == '/') {
+            tmpptr[--tmplen] = '\0';
         }
     }
 


### PR DESCRIPTION
2b06b541ac4a10cbfea0592e0f01a502b02a51ec altered dedotdot to preserve
trailing slashes.  narrow_chroot_path expects FAKECHROOT_BASE to not
have a trailing slash, so they need to be removed manually.
