### PR TITLE
readlink: Avoid overflowing user buffer if FAKECHROOT_BASE is not set

### DIFF
--- a/src/readlink.c
+++ b/src/readlink.c
@@ -65,6 +65,9 @@ wrapper(readlink, READLINK_TYPE_RETURN, (const char * path, char * buf, READLINK
         strncpy(buf, tmpptr, linksize);
     }
     else {
+        if (linksize > bufsiz) {
+            linksize = bufsiz;
+        }
         strncpy(buf, tmp, linksize);
     }
     return linksize;


### PR DESCRIPTION
The `readlink` command would crash with a `free(): invalid next size (normal)` error due to the buffer overflow.