### PR TITLE
Use versioned references to the xattr functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ user's account.
 An example session
 ==================
 
-```sh
+```
 $ id
 uid=1000(dexter) gid=1000(dexter) groups=1000(dexter)
 
 $ fakechroot fakeroot debootstrap sid /tmp/sid
-I: Retrieving Release 
-I: Retrieving Release.gpg 
+I: Retrieving Release
+I: Retrieving Release.gpg
 I: Checking Release signature
 ...
 I: Base system installed successfully.
@@ -85,3 +85,4 @@ fakechroot had found another purposes:
 * to be a supporter for [febootstrap](http://et.redhat.com/~rjones/febootstrap/), the tool which can set up new Fedora system
 * to be a part of [cuntubuntu](https://play.google.com/store/apps/details?id=com.cuntubuntu) - Ubuntu for Android without root
 * to be a supporter for [selenium-chroot](https://github.com/gagern/selenium-chroot) setup
+* to be a supporter for [rpm](https://github.com/rpm-software-management/rpm) test suite

--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,7 @@ AC_CHECK_FUNCS(m4_normalize([
     dladdr
     dlmopen
     dlopen
+    dlvsym
     eaccess
     euidaccess
     execl

--- a/src/getxattr.c
+++ b/src/getxattr.c
@@ -27,7 +27,7 @@
 #include "libfakechroot.h"
 
 
-wrapper(getxattr, ssize_t, (const char * path, const char * name, void * value, size_t size))
+wrapper_versioned(getxattr, "GLIBC_2.3", ssize_t, (const char * path, const char * name, void * value, size_t size))
 {
     debug("getxattr(\"%s\", \"%s\", &value, %zd)", path, name, size);
     expand_chroot_path(path);

--- a/src/lgetxattr.c
+++ b/src/lgetxattr.c
@@ -27,7 +27,7 @@
 #include "libfakechroot.h"
 
 
-wrapper(lgetxattr, ssize_t, (const char * path, const char * name, void * value, size_t size))
+wrapper_versioned(lgetxattr, "GLIBC_2.3", ssize_t, (const char * path, const char * name, void * value, size_t size))
 {
     debug("lgetxattr(\"%s\", \"%s\", &value, %zd)", path, name, size);
     expand_chroot_path(path);

--- a/src/libfakechroot.c
+++ b/src/libfakechroot.c
@@ -143,7 +143,12 @@ void fakechroot_init (void)
 LOCAL fakechroot_wrapperfn_t fakechroot_loadfunc (struct fakechroot_wrapper * w)
 {
     char *msg;
-    if (!(w->nextfunc = dlsym(RTLD_NEXT, w->name))) {;
+
+    if (w->version)
+        w->nextfunc = dlvsym(RTLD_NEXT, w->name, w->version);
+    else
+        w->nextfunc = dlsym(RTLD_NEXT, w->name);
+    if (!w->nextfunc) {
         msg = dlerror();
         fprintf(stderr, "%s: %s: %s\n", PACKAGE, w->name, msg != NULL ? msg : "unresolved symbol");
         exit(EXIT_FAILURE);

--- a/src/libfakechroot.h
+++ b/src/libfakechroot.h
@@ -144,12 +144,16 @@
 #define wrapper_decl_proto(function) \
     extern LOCAL struct fakechroot_wrapper fakechroot_##function##_wrapper_decl SECTION_DATA_FAKECHROOT
 
-#define wrapper_decl(function) \
+#define wrapper_decl_versioned(function, version) \
     LOCAL struct fakechroot_wrapper fakechroot_##function##_wrapper_decl SECTION_DATA_FAKECHROOT = { \
         (fakechroot_wrapperfn_t) function, \
         NULL, \
-        #function \
+        #function, \
+        version \
     }
+
+#define wrapper_decl(function) \
+    wrapper_decl_versioned(function, NULL)
 
 #define wrapper_fn_t(function, return_type, arguments) \
     typedef return_type (*fakechroot_##function##_fn_t) arguments
@@ -171,15 +175,21 @@
     wrapper_proto(function, return_type, arguments)
 #endif
 
-#define wrapper(function, return_type, arguments) \
+#define wrapper_versioned(function, version, return_type, arguments) \
     wrapper_proto(function, return_type, arguments); \
-    wrapper_decl(function); \
+    wrapper_decl_versioned(function, version); \
     return_type function arguments
 
-#define wrapper_alias(function, return_type, arguments) \
+#define wrapper(function, return_type, arguments) \
+    wrapper_versioned(function, NULL, return_type, arguments)
+
+#define wrapper_alias_versioned(function, version, return_type, arguments) \
     wrapper_proto_alias(function, return_type, arguments); \
-    wrapper_decl(function); \
+    wrapper_decl_versioned(function, version); \
     return_type wrapper_fn_name(function) arguments
+
+#define wrapper_alias(function, return_type, arguments) \
+    wrapper_alias_versioned(function, NULL, return_type, arguments)
 
 #define nextcall(function) \
     ( \
@@ -210,6 +220,7 @@ struct fakechroot_wrapper {
     fakechroot_wrapperfn_t func;
     fakechroot_wrapperfn_t nextfunc;
     const char *name;
+    const char *version;
 };
 
 

--- a/src/listxattr.c
+++ b/src/listxattr.c
@@ -27,7 +27,7 @@
 #include "libfakechroot.h"
 
 
-wrapper(listxattr, ssize_t, (const char * path, char * list, size_t size))
+wrapper_versioned(listxattr, "GLIBC_2.3", ssize_t, (const char * path, char * list, size_t size))
 {
     debug("listxattr(\"%s\", &list, %zd)", path, list);
     expand_chroot_path(path);

--- a/src/llistxattr.c
+++ b/src/llistxattr.c
@@ -27,7 +27,7 @@
 #include "libfakechroot.h"
 
 
-wrapper(llistxattr, ssize_t, (const char *path, char *list, size_t size))
+wrapper_versioned(llistxattr, "GLIBC_2.3", ssize_t, (const char *path, char *list, size_t size))
 {
     debug("llistxattr(\"%s\", &list, %zd)", path, list);
     expand_chroot_path(path);

--- a/src/lremovexattr.c
+++ b/src/lremovexattr.c
@@ -25,7 +25,7 @@
 #include "libfakechroot.h"
 
 
-wrapper(lremovexattr, int, (const char * path, const char * name))
+wrapper_versioned(lremovexattr, "GLIBC_2.3", int, (const char * path, const char * name))
 {
     debug("lremovexattr(\"%s\", \"%s\")", path, name);
     expand_chroot_path(path);

--- a/src/lsetxattr.c
+++ b/src/lsetxattr.c
@@ -26,7 +26,7 @@
 #include "libfakechroot.h"
 
 
-wrapper(lsetxattr, int, (const char * path, const char * name, const void * value, size_t size, int flags))
+wrapper_versioned(lsetxattr, "GLIBC_2.3", int, (const char * path, const char * name, const void * value, size_t size, int flags))
 {
     debug("lsetxattr(\"%s\", \"%s\", &value, %zd, %d)", path, name, size, flags);
     expand_chroot_path(path);

--- a/src/removexattr.c
+++ b/src/removexattr.c
@@ -25,7 +25,7 @@
 #include "libfakechroot.h"
 
 
-wrapper(removexattr, int, (const char * path, const char * name))
+wrapper_versioned(removexattr, "GLIBC_2.3", int, (const char * path, const char * name))
 {
     debug("removexattr(\"%s\", \"%s\")", path, name);
     expand_chroot_path(path);

--- a/src/setxattr.c
+++ b/src/setxattr.c
@@ -25,7 +25,7 @@
 #include "libfakechroot.h"
 
 
-wrapper(setxattr, int, (const char * path, const char * name, const void * value, size_t size, int flags))
+wrapper_versioned(setxattr, "GLIBC_2.3", int, (const char * path, const char * name, const void * value, size_t size, int flags))
 {
     debug("setxattr(\"%s\", \"%s\", &value, %zd, %d)", path, name, size, flags);
     expand_chroot_path(path);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -34,6 +34,7 @@ TESTS = \
     t/system.t \
     t/test-r.t \
     t/touch.t \
+    t/xattr.t \
     t/zzarchlinux.t \
     t/zzdebootstrap.t \
     #

--- a/test/t/xattr.t
+++ b/test/t/xattr.t
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+srcdir=${srcdir:-.}
+. $srcdir/common.inc.sh
+
+command -v setfattr >/dev/null 2>&1 || skip_all 'setfattr command is missing (sudo apt-get install attr)'
+command -v attr >/dev/null 2>&1     || skip_all 'attr command is missing (weird, since you have setfattr!)'
+
+prepare 10
+
+for chroot in chroot fakechroot; do
+
+    if [ $chroot = "chroot" ] && ! is_root; then
+        skip $(( $tap_plan / 2 )) "not root"
+    else
+
+        echo "something" > $testtree/$chroot-file
+        $srcdir/$chroot.sh $testtree /usr/bin/setfattr -n user.someattr -v somevalue /$chroot-file || not
+        ok "$chroot added xattr 'someattr' to file"
+
+        t=`$srcdir/$chroot.sh $testtree /usr/bin/getfattr -d /$chroot-file 2>&1 | grep ^user`
+        test "$t" = 'user.someattr="somevalue"' || not
+        ok "$chroot got xattr back" $t
+
+        t=`$srcdir/$chroot.sh $testtree /usr/bin/attr -qg someattr /$chroot-file 2>&1`
+        test "$t" = "somevalue" || not
+        ok "$chroot got someattr back" $t
+
+        $srcdir/$chroot.sh $testtree /usr/bin/attr -r someattr /$chroot-file || not
+        ok "$chroot removed someattr from file"
+
+        t=`$srcdir/$chroot.sh $testtree /usr/bin/getfattr -d /$chroot-file 2>&1`
+        test "$t" = "" || not
+        ok "$chroot got empty xattrs back" $t
+
+        rm $testtree/$chroot-file
+
+    fi
+
+done
+
+cleanup

--- a/test/testtree.sh
+++ b/test/testtree.sh
@@ -60,10 +60,12 @@ for p in \
     '/bin/sh' \
     '/bin/sleep' \
     '/bin/touch' \
+    '/usr/bin/attr' \
     '/usr/bin/basename' \
     '/usr/bin/dirname' \
     '/usr/bin/env' \
     '/usr/bin/find' \
+    '/usr/bin/getfattr' \
     '/usr/bin/id' \
     '/usr/bin/ischroot' \
     '/usr/bin/less' \
@@ -72,6 +74,7 @@ for p in \
     '/usr/bin/perl' \
     '/usr/bin/readlink' \
     '/usr/bin/seq' \
+    '/usr/bin/setfattr' \
     '/usr/bin/sort' \
     '/usr/bin/strace' \
     '/usr/bin/test' \


### PR DESCRIPTION
This prevents fakechroot to binding to the symbols exported by libattr (with symbol version `@ATTR_1.0`), instead looking up the symbols exported from glibc directly.

After attr 2.4.48, binding to the symbols in libattr will cause an infinite recursion, ending in a segmentation fault due to stack overflow.

Also add tests for the xattr functions.

These tests will fail on attr 2.4.48 without using the explicit symbol versions to pull them from glibc, so this test confirms that the commit to use explicit symbol versions does indeed fix that particular issue.

Tested that by reverting the first commit and using attr 2.4.48, the test will fail as expected.

Also checked that the "chroot" variant of the test will work, when the test is executed as root.

Also push some minor updates to README.md.

Fixes #57.
