### PR TITLE
Avoid hangs when calling ldd.fakechroot with unknown arguments

### DIFF
--- a/scripts/ldd.fakechroot.pl
+++ b/scripts/ldd.fakechroot.pl
@@ -155,11 +155,6 @@ sub load_ldsoconf {
 MAIN: {
     my @args = @ARGV;
 
-    if (not @args) {
-        print STDERR "fakeldd: missing file arguments\n";
-        exit 1;
-    }
-
     if (not `sh -c 'command -v objdump'`) {
         print STDERR "fakeldd: objdump: command not found: install binutils package\n";
         exit 1;
@@ -170,8 +165,13 @@ MAIN: {
 
     while ($args[0] =~ /^-/) {
         my $arg = $args[0];
-        shift @ARGV;
+        shift @args;
         last if $arg eq "--";
+    }
+
+    if (not @args) {
+        print STDERR "fakeldd: missing file arguments\n";
+        exit 1;
     }
 
     foreach my $file (@args) {


### PR DESCRIPTION
I observed that ldd.fakechroot can hang when called with `--version`, as the new `config.guess` supplied with recent binutils releases sometimes uses `ldd --version` to determine the build system. I've attempted a fix as attached here.

I haven't investigated actually handling flags - at the moment the intent appears to be to ignore them - so this may not totally fix the problem I was encountering, but at least it will prevent a hang.