### PR TITLE
New `statx` function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 XX Xxx XXXX
 
 * UNRELEASED
+* New `statx(2)` function was added: glibc supports it since 2.28.
 
 ## Version 2.20.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -277,6 +277,7 @@ AC_CHECK_FUNCS(m4_normalize([
     statfs64
     statvfs
     statvfs64
+    statx
     stpcpy
     strchrnul
     strlcpy

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -152,6 +152,7 @@ libfakechroot_la_SOURCES = \
     statfs64.c \
     statvfs.c \
     statvfs64.c \
+    statx.c \
     stpcpy.c \
     strchrnul.c \
     strchrnul.h \

--- a/src/statx.c
+++ b/src/statx.c
@@ -1,0 +1,44 @@
+/*
+    libfakechroot -- fake chroot environment
+    Copyright (c) 2010-2020 Piotr Roszatycki <dexter@debian.org>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+
+#include <config.h>
+
+#ifdef HAVE_STATX
+
+#define _GNU_SOURCE
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "libfakechroot.h"
+
+
+wrapper(statx, int, (int dirfd, const char * pathname, int flags, unsigned int mask, struct statx * statxbuf))
+{
+    char fakechroot_abspath[FAKECHROOT_PATH_MAX];
+    char fakechroot_buf[FAKECHROOT_PATH_MAX];
+    debug("statx(%d, \"%s\", %d, %u, &statxbuf)", dirfd, pathname, flags, mask);
+    expand_chroot_path_at(dirfd, pathname);
+    return nextcall(statx)(dirfd, pathname, flags, mask, statxbuf);
+}
+
+#else
+typedef int empty_translation_unit;
+#endif


### PR DESCRIPTION
Unfortunately it didn't help #67 because nodejs uses `syscall`(2) instead of `statx`(2)...
