### PR TITLE
Stat fix compilation

### DIFF
--- a/src/lstat.c
+++ b/src/lstat.c
@@ -28,19 +28,20 @@
 #include "lstat.h"
 
 
-wrapper(lstat, int, (int ver, const char * filename, struct stat * buf))
+wrapper(lstat, int, (const char * filename, struct stat * buf))
 {
-    debug("lstat(%d, \"%s\", &buf)", ver, filename);
+    char abs_filename[FAKECHROOT_PATH_MAX];
+
+    debug("lstat(\"%s\", &buf)", filename);
 
     if (!fakechroot_localdir(filename)) {
         if (filename != NULL) {
-            char abs_filename[FAKECHROOT_PATH_MAX];
             rel2abs(filename, abs_filename);
             filename = abs_filename;
         }
     }
 
-    return lstat_rel(ver, filename, buf);
+    return lstat_rel(filename, buf);
 }
 
 

--- a/src/lstat.h
+++ b/src/lstat.h
@@ -26,7 +26,7 @@
 
 #ifndef HAVE___LXSTAT
 
-wrapper_proto(lstat, int, (int, const char *, struct stat *));
+wrapper_proto(lstat, int, (const char *, struct stat *));
 
 int lstat_rel(const char *, struct stat *);
 

--- a/src/stat.c
+++ b/src/stat.c
@@ -33,6 +33,8 @@
 
 wrapper(stat, int, (const char * file_name, struct stat * buf))
 {
+    char fakechroot_abspath[FAKECHROOT_PATH_MAX];
+    char fakechroot_buf[FAKECHROOT_PATH_MAX];
     debug("stat(\"%s\", &buf)", file_name);
     expand_chroot_path(file_name);
     return nextcall(stat)(file_name, buf);

--- a/src/stat64.c
+++ b/src/stat64.c
@@ -34,6 +34,8 @@
 
 wrapper(stat64, int, (const char * file_name, struct stat64 * buf))
 {
+    char fakechroot_abspath[FAKECHROOT_PATH_MAX];
+    char fakechroot_buf[FAKECHROOT_PATH_MAX];
     debug("stat64(\"%s\", &buf)", file_name);
     expand_chroot_path(file_name);
     return nextcall(stat64)(file_name, buf);


### PR DESCRIPTION
This is part of effort to port `fakechroot` to musl libc in https://github.com/dex4er/fakechroot/compare/master...sgn:musl-port?expand=1

The port isn't usable yet (`cp.t` is failing).

Those 2 changes should be good with other libc, hence I would like to have them merged first.