### PR TITLE
The strcpy writes the terminating null byte as well.

### DIFF
--- a/src/tmpnam.c
+++ b/src/tmpnam.c
@@ -42,7 +42,7 @@ wrapper(tmpnam, char *, (char * s))
 
     expand_chroot_path(ptr);
 
-    ptr2 = malloc(strlen(ptr));
+    ptr2 = malloc(strlen(ptr) + 1);
     if (ptr2 == NULL) return NULL;
 
     strcpy(ptr2, ptr);


### PR DESCRIPTION
Addressing
```
tmpnam.c:48:5: warning: ‘strcpy’ writing one too many bytes into a region of a size that depends on ‘strlen’ [-Wstringop-overflow=]
   48 |     strcpy(ptr2, ptr);
      |     ^~~~~~~~~~~~~~~~~
tmpnam.c:45:12: note: at offset 0 to an object allocated by ‘malloc’ here
   45 |     ptr2 = malloc(strlen(ptr));
      |            ^~~~~~~~~~~~~~~~~~~
  CCLD     libfakechroot.la
```