### PR TITLE
Wrap fstatat and fstatat64 (glibc 2.33)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -198,6 +198,8 @@ AC_CHECK_FUNCS(m4_normalize([
     freopen64
     fstat
     fstat64
+    fstatat
+    fstatat64
     fts_children
     fts_open
     fts_read

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,6 +61,8 @@ libfakechroot_la_SOURCES = \
     fopen64.c \
     freopen.c \
     freopen64.c \
+    fstatat.c \
+    fstatat64.c \
     fts.c \
     fts64.c \
     ftw.c \

--- a/src/fstatat.c
+++ b/src/fstatat.c
@@ -1,0 +1,42 @@
+/*
+    libfakechroot -- fake chroot environment
+    Copyright (c) 2010, 2021 Piotr Roszatycki <dexter@debian.org>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+
+#include <config.h>
+
+#ifdef HAVE_FSTATAT
+
+#define _ATFILE_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#include <sys/stat.h>
+#include <limits.h>
+#include "libfakechroot.h"
+
+wrapper(fstatat, int, (int dirfd, const char *pathname, struct stat *buf, int flags))
+{
+    char fakechroot_abspath[FAKECHROOT_PATH_MAX];
+    char fakechroot_buf[FAKECHROOT_PATH_MAX];
+    debug("fstatat(%d, \"%s\", &buf, %d)", dirfd, pathname, flags);
+    expand_chroot_path_at(dirfd, pathname);
+    return nextcall(fstatat)(dirfd, pathname, buf, flags);
+}
+
+#else
+typedef int empty_translation_unit;
+#endif

--- a/src/fstatat64.c
+++ b/src/fstatat64.c
@@ -1,0 +1,43 @@
+/*
+    libfakechroot -- fake chroot environment
+    Copyright (c) 2010, 2021 Piotr Roszatycki <dexter@debian.org>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+
+#include <config.h>
+
+#ifdef HAVE_FSTATAT64
+
+#define _ATFILE_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#define _LARGEFILE64_SOURCE
+#include <sys/stat.h>
+#include <limits.h>
+#include "libfakechroot.h"
+
+wrapper(fstatat64, int, (int dirfd, const char *pathname, struct stat64 *buf, int flags))
+{
+    char fakechroot_abspath[FAKECHROOT_PATH_MAX];
+    char fakechroot_buf[FAKECHROOT_PATH_MAX];
+    debug("fstatat64(%d, \"%s\", &buf, %d)", dirfd, pathname, flags);
+    expand_chroot_path_at(dirfd, pathname);
+    return nextcall(fstatat64)(dirfd, pathname, buf, flags);
+}
+
+#else
+typedef int empty_translation_unit;
+#endif


### PR DESCRIPTION
In addition to PR https://github.com/dex4er/fakechroot/pull/85 for fixing ISSUE https://github.com/dex4er/fakechroot/issues/82, add `fstatat` and `fstatat64` syscall wrappers, added in [`glibc 2.33`](https://github.com/bminor/glibc/blob/master/io/Versions#L136).

Fixes failing `test/t/cp.t`.